### PR TITLE
Cpg module

### DIFF
--- a/test/units/modules/storage/hpe3par/test_hpe3par_cpg.py
+++ b/test/units/modules/storage/hpe3par/test_hpe3par_cpg.py
@@ -219,7 +219,7 @@ class TestHpe3parCPG(unittest.TestCase):
     @mock.patch('ansible.modules.storage.hpe.hpe3par_cpg.client')
     def test_cpg_ldlayout_map(self, mock_client):
         mock_client.HPE3ParClient.PORT = 1
-        mock_client.HPE3ParClient.RAID_MAP = {'R6': {'raid_value': 1, 'set_sizes': [1]},
+        mock_client.HPE3ParClient.RAID_MAP = {'R0': {'raid_value': 1, 'set_sizes': [1]},
                                               'R1': {'raid_value': 2, 'set_sizes': [2, 3, 4]},
                                               'R5': {'raid_value': 3, 'set_sizes': [3, 4, 5, 6, 7, 8, 9]},
                                               'R6': {'raid_value': 4, 'set_sizes': [6, 8, 10, 12, 16]}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Ansible modules which enable the user to provision HPE StoreServ 3PAR device using Python 3PAR client to communicate over WSAPI REST interface. Ansible behaves as the orchestrator tool.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
storage/hpe/hpe3par_cpg

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.0 (initial 416bea2d0c) last updated 2018/04/30 04:12:37 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/farhan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/farhan/workspace/ansible/lib/ansible
  executable location = /home/farhan/workspace/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
```

